### PR TITLE
Implement snippet search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 # server
 dev.js
 service-account.json
+
+# misc
+private/

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5840,6 +5840,11 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
+    "fuse.js": {
+      "version": "3.4.6",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-3.4.6.tgz",
+      "integrity": "sha512-H6aJY4UpLFwxj1+5nAvufom5b2BT2v45P1MkPvdGIK8fWjQx/7o6tTT1+ALV0yawQvbmvCF0ufl2et8eJ7v7Cg=="
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5990,9 +5990,9 @@
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
     },
     "handlebars": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.2.tgz",
-      "integrity": "sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",

--- a/client/package.json
+++ b/client/package.json
@@ -12,6 +12,7 @@
     "@types/react-router-dom": "^5.1.2",
     "@types/yup": "^0.26.24",
     "formik": "^2.0.3",
+    "fuse.js": "^3.4.6",
     "http-proxy-middleware": "^0.20.0",
     "materialize-css": "^1.0.0",
     "query-string": "^6.8.3",

--- a/client/src/components/snippets/SnippetList.tsx
+++ b/client/src/components/snippets/SnippetList.tsx
@@ -18,7 +18,7 @@ import FilterSnippetForm from './filterSnippetForm';
 
 
 
-interface Props {
+interface SnippetListProps {
   fetchSnippets: (filters?: any) => void;
   fetchUsers: (selectedTeam: any) => void;
 

--- a/client/src/components/snippets/SnippetList.tsx
+++ b/client/src/components/snippets/SnippetList.tsx
@@ -10,26 +10,101 @@ import {
 import {
   isEmpty,
 } from '../../lib/lib';
+import Fuse from 'fuse.js';
 
 
 
-interface Props {
+interface SnippetListProps {
   fetchSnippets: () => void;
   snippets: Array<Snippet> | null;
   user: User | null;
 }
 
-class SnippetList extends Component<Props> {
-  componentDidMount() {
+interface SnippetListState {
+  snippets: Array<Snippet>;
+  searchText: string;
+}
+
+interface FuseOptions {
+  shouldSort: boolean;
+  tokenize: boolean;
+  keys: Array<string>;
+}
+
+const fuseOpts: FuseOptions = {
+  shouldSort: true,
+  tokenize: true,
+  keys: [
+    'title',
+    'content',
+    'description',
+    'ownerName', 
+  ],
+};
+
+class SnippetList extends Component<SnippetListProps, SnippetListState> {
+  fuse: Fuse<Snippet, FuseOptions> | null = null;
+  
+  constructor(props: SnippetListProps) {
+    super(props);
+
+    this.state = {
+      snippets: props.snippets ? props.snippets : [],
+      searchText: '',
+    };
+  }
+
+  async componentDidMount() {
     // console.log('<SnippetList /> did mount');
     if (this.props.user && !isEmpty(this.props.user)) {
-      this.props.fetchSnippets();
+      await this.props.fetchSnippets();
+      if (this.props.snippets) {
+        this.setState({
+          snippets: this.props.snippets,
+        });
+        this.fuse = new Fuse(this.props.snippets, fuseOpts);
+      }
     }
   }
 
+  renderSearch() {
+    return (
+      <div className='row'>
+        <form onSubmit={(e) => {
+          e.preventDefault();
+          if (this.fuse) {
+            let results: Array<Snippet> = this.props.snippets || [];
+            if (this.state.searchText.length > 0) {
+              results = this.fuse.search(this.state.searchText);
+            }
+            this.setState({
+              snippets: results,
+            });
+          } else {
+            console.error('Fuse search is not initialized');
+          }
+        }}>
+          <input 
+            className='col s9' 
+            type='text' 
+            placeholder='Search within current list of snippets' 
+            value={this.state.searchText}
+            onChange={(e) => {
+              e.preventDefault();
+              this.setState({
+                searchText: e.target.value,
+              });
+            }} 
+          />
+          <input className='col s2 push-s1 btn waves-effect waves-light' type='submit' value='Search' />
+        </form>
+      </div>
+    );
+  }
+
   renderSnippets() {
-    if (this.props.snippets && this.props.snippets.length > 0) {
-      return this.props.snippets.map( (snippet: any) => {
+    if (this.state.snippets && this.state.snippets.length > 0) {
+      return this.state.snippets.map( (snippet: any) => {
         return (
           <li key={snippet.title} className='collection-item'>
             <div>
@@ -61,9 +136,9 @@ class SnippetList extends Component<Props> {
     )
   }
   
-  // FIXME: render method called 4 times for any update to state
   render() {
     // console.log("snippet list props", this.props);
+
     return (
       <ul className='collection with-header'>
         <li className='collection-header lighten-5 blue'>
@@ -74,6 +149,9 @@ class SnippetList extends Component<Props> {
           >
             Add Snippet
           </Link>
+        </li>
+        <li className='collection-header'>
+          {this.renderSearch()}
         </li>
         {this.renderSnippets()}
       </ul>


### PR DESCRIPTION
Overview of Requirements:
- [x] Users should be able to search snippets.

We have decided to keep the scope of any search to one specific team. In other words, the user must select a team first to be able to search for a snippet (and the search is limited to that team). However, with the "All" option within the team navigation, users can do a "global" search by selecting that option.